### PR TITLE
Use "not-empty" empty string to disable gadget

### DIFF
--- a/lib/usb_gadget.ex
+++ b/lib/usb_gadget.ex
@@ -150,7 +150,7 @@ defmodule USBGadget do
 
     device_name
     |> udc_path()
-    |> File.write("")
+    |> File.write("\n")
   end
 
   # Private Helpers


### PR DESCRIPTION
Fixes #5 

This fixes an issue where gadgets could not be disabled. I'm not 100% sure why a "real" empty string doesn't work. Maybe nothing is written to the file at all in this case. However simply saving a newline character does work. This is also consistent with disabling the gadget from a shell where a `echo "" > UDC` will also write a empty string followed be newline.